### PR TITLE
Swap in vlc state machine code for testing

### DIFF
--- a/config.h
+++ b/config.h
@@ -12,7 +12,7 @@
 #define SUBJECT_ID "2"
 
 //define the file that contains the name of the trial table
-#define TRIALFILE "./TrialTables/Static_Mful.txt"  
+#define TRIALFILE "./TrialTables/Named_Mful.txt"  
 
 //define the folder where the data will go (this folder must exist!)
 #define DATAPATH "C:/Users/MRRI/Desktop/imitation_data/"
@@ -80,10 +80,10 @@
 
 //screen dimensions
 //   (note, the Elitebook wants dimensions that are slightly larger than the screen, with WINDOWED set to true!)
-#define SCREEN_WIDTH  1602
-#define SCREEN_HEIGHT  901
-//#define SCREEN_WIDTH  1440
-//#define SCREEN_HEIGHT  900
+//#define SCREEN_WIDTH  1602
+//#define SCREEN_HEIGHT  901
+#define SCREEN_WIDTH  1440
+#define SCREEN_HEIGHT  900
 
 //video dimensions
 //Videos are in 16:9 format

--- a/imitation.vcxproj
+++ b/imitation.vcxproj
@@ -94,7 +94,7 @@
     <ClInclude Include="TargetFrame.h" />
     <ClInclude Include="Timer.h" />
     <ClInclude Include="TrackBird.h" />
-    <ClInclude Include="vlcVideoPlayer.h" />
+    <ClInclude Include="vlcVideoPlayerSM.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Circle.cpp" />
@@ -110,7 +110,7 @@
     <ClCompile Include="SpeedBar.cpp" />
     <ClCompile Include="Timer.cpp" />
     <ClCompile Include="TrackBird.cpp" />
-    <ClCompile Include="vlcVideoPlayer.cpp" />
+    <ClCompile Include="vlcVideoPlayerSM.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/imitation.vcxproj.filters
+++ b/imitation.vcxproj.filters
@@ -60,7 +60,7 @@
     <ClInclude Include="TrackBird.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="vlcVideoPlayer.h">
+    <ClInclude Include="vlcVideoPlayerSM.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -104,7 +104,7 @@
     <ClCompile Include="TrackBird.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="vlcVideoPlayer.cpp">
+    <ClCompile Include="vlcVideoPlayerSM.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/main.cpp
+++ b/main.cpp
@@ -20,7 +20,7 @@
 #include "Sound.h"
 #include "Timer.h"
 #include "Image.h"
-#include "vlcVideoPlayer.h"
+#include "vlcVideoPlayerSM.h"
 
 #include "config.h"
 
@@ -1059,6 +1059,7 @@ static void draw_screen()
 
 	player->Draw();
 
+	Vid->Update();
 
 	// Draw text
 	endtext->Draw(float(PHYSICAL_WIDTH)/2.0f,float(PHYSICAL_HEIGHT)*2.0f/3.0f);
@@ -1148,8 +1149,9 @@ void game_update()
 		for (int b = 0; b < 2; b++)
 			for (int a = 0; a < NINSTRUCT; a++)
 				instructimages[b][a]->Off();
-
-		Vid->Invisible();
+		
+		if (Vid->VisibleState() != 0)
+			Vid->Invisible();
 
 		if( returntostart && nextstateflag)  //hand is in the home position and the experimenter asked to advance the experiment
 		{
@@ -1393,7 +1395,7 @@ void game_update()
 	case ShowContext:
 
 		//check if the hand moves too early; if so, reset the trial
-		if (player->Distance(startCircle) > START_RADIUS)
+		if (!mvtStarted && player->Distance(startCircle) > START_RADIUS)
 		{	//detected movement too early; 
 			//std::cerr << "Player: " << player->GetX() << " , " << player->GetY() << " , " << player->GetZ() << std::endl;
 			//std::cerr << "Circle: " << startCircle->GetX() << " , " << startCircle->GetY() << " , " << startCircle->GetZ() << std::endl;
@@ -1438,10 +1440,6 @@ void game_update()
 			state = WaitStim;
 			std::cerr << "False start; returning to WAITSTIM state." << std::endl;
 		}
-
-		//if none of the above, reassert play
-		//if (Target.vidstatus == 1 && !Vid->HasStarted() && !Vid->HasEnded())
-		//	Vid->Play();
 
 		
 		if (!donePlayingContext && (itemsounds[curtr.context-1]->IsPlaying() == 0))
@@ -1493,6 +1491,7 @@ void game_update()
 			if ((curtr.showcontext > 0) && (curtr.context-1 < NcontextTexts))
 				contextText[curtr.context-1]->Off();
 			Vid->Pause();
+			//Vid->Stop();
 			Vid->Invisible();
 			Target.vidstatus = 0;
 			//items[curtr.context-1]->Off();
@@ -1528,7 +1527,7 @@ void game_update()
 			std::cerr << "False start; returning to WAITSTIM state." << std::endl;
 		}
 
-		if (!vidEnded && Vid->HasEnded())
+		if (!vidEnded && (Vid->HasEnded() == 1))
 		{
 			vidEnded = true;
 			hoverTimer->Reset();
@@ -1558,10 +1557,6 @@ void game_update()
 		}
 
 		
-		//if none of the above, reasset play
-		//if (Target.vidstatus == 1 && !vidEnded && !Vid->HasStarted() && !Vid->HasEnded())
-		//	Vid->Play();
-
 		//if video finished playing and we are ready to move on...
 		if (!mvtStarted && vidEndedAck && (trialTimer->Elapsed() > curtr.srdur) )  //prompt start signal
 		{

--- a/vlcVideoPlayerSM.cpp
+++ b/vlcVideoPlayerSM.cpp
@@ -1,0 +1,997 @@
+#include "vlcVideoPlayerSM.h"
+
+
+void DrawOtherStuff(void (*func)(SDL_Renderer *renderer))
+{
+	 drawfunc = func;
+}
+
+
+// VLC prepares to render a video frame.
+void* lock(void *data, void **p_pixels) {
+
+    struct ctx *c = (ctx *)data;
+
+    int pitch;
+    SDL_LockMutex(c->mutex);
+    SDL_LockTexture(c->texture, NULL, p_pixels, &pitch);
+
+    return NULL; // Picture identifier, not needed here.
+}
+
+
+// VLC just rendered a video frame.
+void unlock(void *data, void *id, void *const *p_pixels) {
+
+    struct ctx *c = (ctx *)data;
+
+    uint16_t *pixels = (uint16_t *)*p_pixels;
+
+    // We can also render stuff.
+	/*
+    int x, y;
+    for(y = 10; y < 40; y++) {
+        for(x = 10; x < 40; x++) {
+            if(x < 13 || y < 13 || x > 36 || y > 36) {
+                pixels[y * VIDEOWIDTH + x] = 0xffff;
+            } else {
+                // RV16 = 5+6+5 pixels per color, BGR.
+                pixels[y * VIDEOWIDTH + x] = 0x02ff;
+            }
+        }
+    }
+	*/
+
+    SDL_UnlockTexture(c->texture);
+    SDL_UnlockMutex(c->mutex);
+}
+
+// VLC wants to display a video frame.
+void display(void *data, void *id) {
+
+    struct ctx *c = (ctx *)data;
+
+    //c->rect.w = VIDEOWIDTH;
+    //c->rect.h = VIDEOHEIGHT;
+	//c->rect.x = c->xpos - c->rect.w/2;
+	//c->rect.y = c->ypos - c->rect.h/2;
+
+	if (c->showVideo)
+	{
+		SDL_ShowWindow(c->window);
+		SDL_SetRenderDrawColor(c->renderer, 255, 255, 255, 255);
+		SDL_RenderClear(c->renderer);
+		SDL_RenderCopy(c->renderer, c->texture, NULL, &(c->rect));
+		
+		if (drawfunc  != NULL)
+			drawfunc(c->renderer);
+		/*SDL_Rect rect;
+		rect.w = SCREEN_WIDTH/2;
+		rect.h = SCREEN_HEIGHT/12;
+		rect.x = SCREEN_WIDTH/2 - rect.w/2;
+		rect.y = SCREEN_WIDTH/2 - rect.h/2;
+	
+		SDL_SetRenderDrawColor(c->renderer, 255, 0, 0, 255);
+		//SDL_RenderClear(c->renderer);
+		SDL_RenderDrawRect(c->renderer, &rect);
+		*/
+	
+		SDL_RenderPresent(c->renderer);
+	}
+	else
+	{
+		SDL_SetRenderDrawColor(c->renderer, 255, 255, 255, 255);
+		SDL_RenderClear(c->renderer);
+		SDL_HideWindow(c->window);
+	}
+}
+
+
+
+
+Video::Video(const char* fname, int x, int y, int w, int h, int* errorcode) //SDL_Renderer *renderer, SDL_Texture *texture, SDL_mutex *mutex, SDL_Rect rect)
+{
+	//Note, this constructor does the "bad" thing of potentially failing, in which case it does not return a valid initialized object.
+	//We need an external way to catch when this happens. To do so, we will pass it an "errorcode" that it will write into before it exits.
+	//Then we can look at the value of the error code after calling the constructor. If the error code is 0, the constructor succeeded;
+	//otherwise, the value of the error code indicates at what stage the initialization failed.
+
+	*errorcode = 0;
+
+	isValid = 1;
+
+
+	//we need absolute paths, so we must figure out the project directory
+	char *bpath = SDL_GetBasePath();
+	std::string basepath;
+	basepath.assign(bpath);
+	//std::cerr << "BasePath: " << basepath.c_str() << std::endl;
+	basepath.erase(basepath.rfind("\\"),1); //get rid of the last slash in the path
+	basepath.erase(basepath.rfind("\\")+1,10); //get rid of the "Debug" folder name to get to the project folder
+	//std::cerr << "ModBasePath: " << basepath.c_str() << std::endl;
+
+    //Set the environmental variable to point to the VLC plugins directory
+    //   If this isn't set properly, libvlc_new() will not work!
+	//NOTE: Sometimes VLC still won't initialize even with this workaround; if libvlc_new() returns NULL,
+	//      just drop a copy of the VLC plugins folder into the Debug folder.
+	std::string envpathcmd;
+	envpathcmd.assign("VLC_PLUGIN_PATH=");
+	envpathcmd.append(basepath.c_str());
+	envpathcmd.append("vlc-3.0.6\\plugins");
+	_putenv(envpathcmd.c_str());
+	std::cerr << "VLC_PLUGIN_PATH=" << getenv("VLC_PLUGIN_PATH") << std::endl;	
+    //printf("VLC_PLUGIN_PATH=%s\n", getenv("VLC_PLUGIN_PATH"));
+
+	//we will set up a dedicated window and renderer for the video, as it plays asynchronously
+	context.window = SDL_CreateWindow(
+            "Vidplayer",
+            float(x)-float(w)/2.0f,
+            float(y)-float(h)/2.0f,
+            w, h,
+            SDL_WINDOW_BORDERLESS | SDL_WINDOW_ALWAYS_ON_TOP | SDL_WINDOW_SKIP_TASKBAR); // 
+    if (!context.window)
+	{
+        std::cerr << "Couldn't create window: " << SDL_GetError() << std::endl;
+		*errorcode = 1;
+		isValid = 0;
+		//return;
+	}
+
+    context.renderer = SDL_CreateRenderer(context.window, -1, 0);
+    if (!context.renderer){
+        std::cerr << "Couldn't create renderer: " << SDL_GetError() << std::endl;
+		*errorcode = 2;
+		isValid = 0;
+		//return;
+	}
+
+	//set the window position in absolute pixel space on the screen
+	context.xpos = x;
+	context.ypos = y;
+	
+	//create a texture to put the video in, which is the same size as the window
+	context.texture = SDL_CreateTexture(
+            context.renderer,
+            SDL_PIXELFORMAT_BGR565, SDL_TEXTUREACCESS_STREAMING,
+            w, h);
+    if (!context.texture) {
+        std::cerr << "Couldn't create texture: " << SDL_GetError() << std::endl;
+		*errorcode = 3;
+		isValid = 0;
+		//return;
+    }
+
+    context.mutex = SDL_CreateMutex();
+
+	//set the video frame to fill the texture/window
+	context.rect.w = w;
+	context.rect.h = h;
+	context.rect.x = 0;
+	context.rect.y = 0;
+	
+	//set up some libVLC initialization parameters
+	
+	char const *vlc_argv[] = {
+        "--no-audio", // Don't play audio.
+        "--no-xlib", // Don't use Xlib.
+        // Apply a video filter.
+        //"--video-filter", "sepia",
+        //"--sepia-intensity=200"
+    };
+    int vlc_argc;
+	
+
+	//initialize the special drawfunc to be null
+	drawfunc = NULL;
+	
+	vlc_argc = sizeof(vlc_argv) / sizeof(*vlc_argv);
+	//std::cout << vlc_argc << " - " << vlc_argv[0] << " " << vlc_argv[1] << std::endl;
+	libvlc = libvlc_new(vlc_argc, vlc_argv);
+	
+	// Initialise libVLC.
+    //libvlc = libvlc_new(0, NULL);
+    if(libvlc == NULL) {
+		std::cerr << "LibVLC initialization failure." << std::endl;
+		*errorcode = 4;
+		isValid = 0;
+		return;
+		//exit;
+        //return EXIT_FAILURE;
+    }
+
+	//set up the video file to be played
+	//libVLC wants an absolute path, so we will start from the project directory path we figured out above
+	std::stringstream vidpath;
+	int d = 0;
+	vidpath << basepath.c_str() << VIDEOPATH << fname; //"\\Video" << d << ".divx";
+	std::cerr << "VidPath: " << vidpath.str().c_str() << std::endl;
+
+	//check if the path exists. For some reason libVLC doesn't do this check correctly so we have to do it manually!
+	if (!PathFileExistsA(vidpath.str().c_str()))
+	{
+		std::cerr << "Video file/path does not exist." << std::endl;
+		*errorcode = 5;
+		isValid = 0;
+		return;
+	}
+
+	//open the video file
+	m = libvlc_media_new_path(libvlc, vidpath.str().c_str());
+	if (m == NULL)
+	{
+		std::cerr << "Media path not valid." << std::endl;
+		*errorcode = 6;
+		isValid = 0;
+		return;
+	}
+	//else
+		//std::cerr << "Media path: " << m << std::endl;
+
+    mp = libvlc_media_player_new_from_media(m);
+	if (mp == NULL)
+	{
+		std::cerr << "Media Player not created." << std::endl;
+		*errorcode = 7;
+		isValid = 0;
+		return;
+	}
+
+    libvlc_media_release(m);
+
+	libvlc_video_set_scale(mp,1.5);		
+
+    libvlc_video_set_callbacks(mp, lock, unlock, display, &context);
+
+    libvlc_video_set_format(mp, "RV16", w, h, w*2);
+
+	mpevent = libvlc_media_player_event_manager(mp);
+	ResetStatus();
+	GetStatus();
+
+	context.showVideo = 0;
+	
+	isVisible = 0;
+
+	Invisible();  //make the window invisible until we need it
+
+	std::cerr << "Video: " << vidpath.str().c_str() << " load complete: status = " << *errorcode << "." << std::endl;
+	//set up the State Machine
+	state = Idle;
+	enteredstate = false;
+	
+	requestplay = 0;
+	requeststop = 0;
+	requestpause = 0;
+	requestrewind = 0;
+	requestload = 0;
+	
+
+}
+
+//function to control/update the state machine
+int Video::Update()
+{
+
+	int status = 0;
+
+	//if the video isn't valid, don't do anything!
+	if (!isValid)
+	{
+		if (requestload == 1)
+			state = Load;
+		else
+			state = Idle;
+
+		return(-1);
+	}
+	
+	GetStatus();
+
+	switch(state)
+	{
+		case Load:
+			
+			//this is just an empy state to wait until the video has finished loading
+
+			if (requestload == 0)
+			{
+				std::cerr << ">>Leaving VidLoad state to VidIdle state." << std::endl;
+				state = Idle;
+			}
+
+			break; //end load state
+
+		case Idle:
+			//we sit here until a request to play comes in
+
+			//request to play
+			if (requestplay == 1)
+			{
+				//request to play has come in; try to play
+				context.showVideo = 1;
+				if (isVisible == 0)
+					Visible();
+				
+				status = libvlc_media_player_play(mp);
+				std::cerr << ">>VidIdle state: Play requested." << std::endl;
+
+				if (status == 0)
+					requestplay = 2;
+			}
+			else if (requestplay == 2)
+			{
+				
+				if (mpstate == libvlc_Playing)
+				{
+					std::cerr << ">>Leaving VidIdle state to VidPlay state." << std::endl;
+					state = Playing;
+				}
+			}
+
+			//request to load a new video
+			if (requestload == 1)
+			{
+				std::cerr << ">>Leaving VidIdle state to VidLoad state." << std::endl;
+				state = Load;
+			}
+
+			//request rewind
+			if (requestrewind == 1)
+			{
+				std::cerr << ">>Leaving VidIdle state to VidRewind state." << std::endl;
+				state = Rewind;
+			}
+
+			if (requeststop == 1)
+				requeststop = 0; //ignore this request since we are already stopped
+			if (requestpause == 1)
+				requestpause = 0; //ignore this request since we are already stopped
+
+
+			break; //end Idle state
+
+		case Playing:
+
+			requestplay = 0;
+			hasStarted = 1;
+
+			//see if the state has changed; if so, obey this transition
+			if (mpstate == libvlc_Stopped)
+			{
+				std::cerr << ">>Leaving VidPlay state to VidStopped state." << std::endl;
+				state = Stopped;
+			}
+			else if (mpstate == libvlc_Ended)
+			{
+				std::cerr << ">>Leaving VidPlay state to VidEnded state." << std::endl;
+				state = Ended;
+			}
+			else if (mpstate == libvlc_Paused)
+			{
+				std::cerr << ">>Leaving VidPlay state to VidPaused state." << std::endl;
+				state = Paused;
+			}
+
+			//if we haven't transitioned states, check if there are any transition requests
+			if (requestpause == 1)
+			{
+				libvlc_media_player_pause(mp);
+
+				requestpause = 2;
+			}
+			else if (requeststop == 1)
+			{
+				libvlc_media_player_stop(mp);
+				std::cerr << ">>VidPlay state: Stop requested." << std::endl;
+				requeststop = 2;
+			}
+			
+			
+			break; //end play state
+
+		case Paused:
+
+			requestpause = 0;
+
+			//see if the state has changed; if so, obey this transition
+			if (mpstate == libvlc_Stopped)
+			{
+				std::cerr << ">>Leaving VidPaused state to VidStopped state." << std::endl;
+				state = Stopped;
+			}
+			else if (mpstate == libvlc_Ended)
+			{
+				std::cerr << ">>Leaving VidPaused state to VidEnded state." << std::endl;
+				state = Ended;
+			}
+			else if (mpstate == libvlc_Playing)
+			{
+				std::cerr << ">>Leaving VidPaused state to VidPlay state." << std::endl;
+				state = Playing;
+			}
+
+			//if we haven't transitioned states, check if there are any transition requests
+			if (requestplay == 1)
+			{
+				//request to play has come in; try to play
+				context.showVideo = 1;
+				if (isVisible == 0)
+					Visible();
+				
+				std::cerr << ">>VidPaused state: Play requested." << std::endl;
+				status = libvlc_media_player_play(mp);
+
+				if (status == 0)
+					requestplay = 2;
+				else
+					state = Idle;
+			}
+			else if (requeststop == 1)
+			{
+				std::cerr << ">>VidPaused state: Stop requested." << std::endl;
+				libvlc_media_player_stop(mp);
+
+				requeststop = 2;
+			}
+			else if (requestrewind == 1)
+			{
+				std::cerr << ">>VidPaused state: Rewind requested." << std::endl;
+				state = Rewind;
+			}
+			
+
+			break; //end paused state
+
+		case Stopped:
+
+			requeststop = 0;
+			hasStopped = 1;
+
+			//see if the state has changed; if so, obey this transition
+			if (mpstate == libvlc_Ended)
+			{
+				std::cerr << ">>Leaving VidStopped state to VidEnded state." << std::endl;
+				state = Ended;
+			}
+			else if (mpstate == libvlc_Playing)
+			{
+				std::cerr << ">>Leaving VidStopped state to VidPlay state." << std::endl;
+				state = Playing;
+			}
+
+			if (requestplay==1)
+			{
+				//request to play has come in; try to play
+				context.showVideo = 1;
+				if (isVisible == 0)
+					Visible();
+				
+				std::cerr << ">>VidStopped state: Play requested." << std::endl;
+				status = libvlc_media_player_play(mp);
+				
+				if (status == 0)
+					requestplay = 2;
+				else
+					state = Idle;
+			}
+			else if (requestpause == 1)
+				requestpause = 0;	//we don't accept this request because we are not playing
+			else if (requestrewind == 1)
+			{
+				std::cerr << ">>VidStopped state: Rewind requested." << std::endl;
+				state = Rewind;
+			}
+
+			break; //end stopped state
+
+		case Ended:
+
+			hasEnded = 1;
+
+			if (requestrewind == 1)
+			{
+				std::cerr << ">>Leaving VidEnded state to Rewind state." << std::endl;
+				state = Rewind;
+			}
+			
+			if (requestplay == 1)
+			{
+				std::cerr << ">>VidEnded state: Play requested. Rewinding first." << std::endl;
+
+				//we must rewind first
+				requestrewind = 1;
+				state = Rewind;
+			
+				//we will keep the play request active so that when we get back to the Idle state we can start playing right away
+				
+			}
+
+			//we will automatically proceed to rewind the video
+
+			break; //end ended state
+
+		case Rewind:
+
+			if (isVisible == 1)
+				Invisible();
+			context.showVideo = 0;
+
+			//to rewind we need to be in play state
+			if (requestrewind == 1)
+			{
+				if (mpstate == libvlc_Ended)
+				{
+					std::cerr << ">> Rewind state = Ended; Stop requested." << std::endl;
+
+					//we need to change the state to stopped first otherwise we cannot play
+					libvlc_media_player_stop(mp);
+					
+					//if (mpstate = libvlc_Stopped)
+					//	requestrewind = 2;
+				}
+				else if (mpstate == libvlc_Paused)
+				{
+					//if we are paused this is a "play" state, so we can just rewind without having to play first
+					requestrewind = 2;
+				}
+				else //(mpstate == libvlc_Stopped)
+				{
+					std::cerr << ">> Rewind state = Stopped; Play requested." << std::endl;
+
+					status = libvlc_media_player_play(mp);
+				
+					if (status == 0)
+						requestrewind = 2;
+				}
+			}
+			
+			if (requestrewind == 2)
+			{
+				//now that we are playing we can set the position and stop - we need to do this quickly before we transition back to the Ended state
+				libvlc_media_player_set_position(mp,0.0f);
+				vidPos = libvlc_media_player_get_position(mp);
+				std::cerr << ">>Video position: " << vidPos  << std::endl;  //<< " : " << libvlc_media_player_get_time(mp)
+				if ((vidPos - 0.0f) < 1e-4)
+					status = 1;
+				
+				requestrewind = 3;
+
+			}
+			else if (requestrewind == 3)
+			{
+				std::cerr << ">> Rewind state = Play/Pos Reset; Stop requested." << std::endl;
+				libvlc_media_player_set_position(mp,0.0f);  //reset the position again just in case there was a long delay before we got baak here
+				libvlc_media_player_stop(mp);
+				
+				ResetStatus();
+				requestrewind = 0;
+				state = Idle;
+				std::cerr << ">>Leaving VidRewind state to VidIdle state." << std::endl;
+			}
+			
+			break; //end rewind state
+
+	} //end switch
+
+
+}
+
+
+
+
+void Video::SetPos(int x, int y)
+{
+	context.xpos = x;
+	context.ypos = y;
+
+}
+
+
+void Video::SetValidStatus(int status)
+{
+	isValid = status;
+}
+
+int Video::IsValid()
+{
+	return(isValid);
+}
+
+
+int Video::GetStatus()
+{
+
+	float pos;
+
+	if (!isValid)
+		return(-1);
+
+	//get the status of the video, and update some status flags
+	mpstate = libvlc_media_get_state(m);
+
+	/*
+	if (hasStarted == 0 && (mpstate == libvlc_Playing))
+	{
+		hasStarted = 1;
+		hasEnded = 0;
+	}
+	else if (hasStarted == 1 && ((mpstate == libvlc_Stopped && (vidPos-1.0)<1e-3) || mpstate == libvlc_Ended) ) //(mpstate == libvlc_Stopped && (pos-1.0)<1e-3) || )
+	{
+		hasEnded = 1;
+		//hasStarted = 0; //we will not clear this until requested separately
+	}
+	else if (hasStarted == 1 && (mpstate == libvlc_Stopped || mpstate == libvlc_Paused) )
+	{
+		hasStopped = 1;
+	}
+	*/
+
+	//std::cerr << "  Video Play Status: " << mpstate << " : (" << hasStarted << "," << hasEnded << ")." << std::endl;
+	
+	return(mpstate);
+}
+
+int Video::HasStarted()
+{
+	if (!isValid)
+		return(-1);
+
+	return(hasStarted);
+}
+
+int Video::HasEnded()
+{
+	if (!isValid)
+		return(-1);
+
+	return(hasEnded);
+}
+
+
+int Video::HasStopped()
+{
+	if (!isValid)
+		return(-1);
+
+	return(hasStopped);
+}
+
+void Video::ResetStatus()
+{
+	hasStarted = 0;
+	hasEnded = 0;
+	hasStopped = 0;
+
+	std::cerr << ">Vid status flags reset" << std::endl;
+}
+
+
+int Video::Play()
+{
+	//returns 0 if playback started.
+
+	if (!isValid)
+		return(-1);
+
+	requestplay = 1;
+
+	/*
+	if (mpstate == libvlc_Ended)
+	{
+		
+		libvlc_media_player_set_position(mp,0.0f); //reset the position so we can play again
+		vidPos = libvlc_media_player_get_position(mp);
+		std::cerr << "Video play from reset position: " << vidPos  << std::endl;  //<< " : " << libvlc_media_player_get_time(mp)
+		
+		GetStatus();
+
+	}
+	else if ((mpstate != libvlc_Playing)) // && ((SDL_GetTicks() - VisTime) > 20))
+	{
+		//start playing the video
+		status = libvlc_media_player_play(mp);
+		std::cerr << "Play video." << std::endl;
+
+		//VidIsPlaying = 1;
+		//libvlc_event_attach(mpevent,libvlc_MediaPlayerEndReached,videoEnded,VidIsPlaying); //set up a callback to detect video end
+
+		visTime = SDL_GetTicks();
+
+		GetStatus();
+
+		vidPos = libvlc_media_player_get_position(mp);
+
+	}
+	else if (mpstate == libvlc_Playing)
+	{
+		status = 1;
+		vidPos = libvlc_media_player_get_position(mp);
+	}
+	else
+		status = 0;
+
+	std::cerr << "VidPlay State: " << libvlc_media_get_state(m) << std::endl;
+	*/
+
+	return(0);
+}
+
+int Video::Stop()
+{
+	int status = 0;
+
+	if (!isValid)
+		return(-1);
+
+	requeststop = 1;
+
+	/*
+	context.showVideo = 0;
+	//Invisible();
+
+	
+	if (!(mpstate == libvlc_Ended) && !(mpstate == libvlc_Stopped) ) //&& !(mpstate == libvlc_Paused)
+	{
+		std::cerr << "Video stop requested...";
+		//libvlc_media_player_stop(mp);
+		//libvlc_media_player_pause(mp);
+		libvlc_media_player_stop(mp);
+		std::cerr << " done." << std::endl;
+		status = 1;
+
+		GetStatus();
+	
+	}
+	*/
+
+	return(0);
+}
+
+int Video::Pause()
+{
+
+	if (!isValid)
+		return(-1);
+
+	requestpause = 1;
+
+	/*
+	int status = 0;
+	context.showVideo = 0;
+
+	libvlc_media_player_pause(mp);
+	std::cerr << "Video pause requested." << std::endl;
+
+	GetStatus();
+	if (mpstate == libvlc_Paused)
+		status = 1;
+	*/
+	return(0);
+
+}
+
+
+int Video::ResetVid()
+{
+	if (!isValid)
+		return(-1);
+
+	requestrewind = 1;
+
+	/*
+	int status = 0;
+	
+		}
+	else if (mpstate == libvlc_Ended)
+	{
+		//from the ended state, resetting the position can cause problems...
+		//we ask to stop the video to change its state, then we can play and reset its position.
+
+		libvlc_media_player_stop(mp);
+		libvlc_media_player_play(mp);
+		libvlc_media_player_set_position(mp,0.0f);
+		vidPos = libvlc_media_player_get_position(mp);
+		libvlc_media_player_stop(mp);
+		std::cerr << "Video position: " << vidPos  << std::endl;  //<< " : " << libvlc_media_player_get_time(mp)
+		if ((vidPos - 0.0f) < 1e-4)
+			status = 1;
+		
+	}
+	else if (mpstate == libvlc_Playing)
+	{
+		libvlc_media_player_set_position(mp,0.0f);
+		vidPos = libvlc_media_player_get_position(mp);
+		std::cerr << "Video position: " << vidPos  << std::endl;  //<< " : " << libvlc_media_player_get_time(mp)
+		if ((vidPos - 0.0f) < 1e-4)
+			status = 1;
+		libvlc_media_player_stop(mp);
+		
+	}
+	else if (mpstate == libvlc_Paused)
+	{
+		//libvlc_media_player_play(mp);  //from the paused state, it seems like we can reset the position without first playing
+		libvlc_media_player_set_position(mp,0.0f);
+		vidPos = libvlc_media_player_get_position(mp);
+		std::cerr << "Video position: " << vidPos  << std::endl;  //<< " : " << libvlc_media_player_get_time(mp)
+		if ((vidPos - 0.0f) < 1e-4)
+			status = 1;
+		libvlc_media_player_stop(mp);
+	}
+
+	std::cerr << "Video State: " << libvlc_media_get_state(m) << std::endl;
+
+	ResetStatus();
+
+	return(status);
+	*/
+}
+
+int Video::VidLoad(const char* fname)
+{
+	int status = 0;
+
+	int w = context.rect.w;
+	int h = context.rect.h;
+
+	if (isValid > 0)
+	{
+		
+		// Stop stream and clean up libVLC.
+		if (hasStopped == 0)
+			libvlc_media_player_stop(mp);
+
+		libvlc_media_player_release(mp);
+	}
+	
+	//flag that we tried to load
+	requestload = 0;
+
+	//set up the video file to be played
+	//libVLC wants an absolute path, so we will figure out the project directory
+	char *bpath = SDL_GetBasePath();
+	std::string basepath;
+	basepath.assign(bpath);
+	//std::cerr << "BasePath: " << basepath.c_str() << std::endl;
+	basepath.erase(basepath.rfind("\\"),1); //get rid of the last slash in the path
+	basepath.erase(basepath.rfind("\\")+1,10); //get rid of the "Debug" folder name to get to the project folder
+	//std::cerr << "ModBasePath: " << basepath.c_str() << std::endl;
+
+	std::stringstream vidpath;
+	int d = 0;
+	vidpath << basepath.c_str() << VIDEOPATH << fname; //"\\Video" << d << ".divx";
+	std::cerr << "VidPath: " << vidpath.str().c_str() << std::endl;
+
+	//check if the path exists. For some reason libVLC doesn't do this check correctly so we have to do it manually!
+	if (!PathFileExistsA(vidpath.str().c_str()))
+	{
+		std::cerr << "Video file/path does not exist." << std::endl;
+		status = 5;
+		isValid = 0;
+		return(status);
+	}
+
+	//open the video file
+	m = libvlc_media_new_path(libvlc, vidpath.str().c_str());
+	if (m == NULL)
+	{
+		std::cerr << "Media path not valid." << std::endl;
+		status = 6;
+		isValid = 0;
+		return(status);
+	}
+	//else
+		//std::cerr << "Media path: " << m << std::endl;
+
+    mp = libvlc_media_player_new_from_media(m);
+	if (mp == NULL)
+	{
+		std::cerr << "Media Player not created." << std::endl;
+		status = 7;
+		isValid = 0;
+		return(status);
+	}
+
+    libvlc_media_release(m);
+
+	libvlc_video_set_scale(mp,1.5);		
+
+    libvlc_video_set_callbacks(mp, lock, unlock, display, &context);
+
+    libvlc_video_set_format(mp, "RV16", w, h, w*2);
+
+	mpevent = libvlc_media_player_event_manager(mp);
+	ResetStatus();
+	GetStatus();
+
+	context.showVideo = 0;
+	
+	Invisible();  //make the window invisible until we need it
+
+	return(0);
+}
+
+
+int Video::LoadNewVid(const char* fname)
+{
+	int status;
+
+	requestload = 1;
+	status = VidLoad(fname);
+
+	if (status != 0)
+		isValid = 0;
+
+	//requestload = 0;
+
+	return(status);
+
+}
+
+void Video::Visible()
+{
+	
+	Uint32 winFlags;
+
+	SDL_ShowWindow(context.window);
+	winFlags = SDL_GetWindowFlags(context.window);
+	if ((winFlags & SDL_WINDOW_SHOWN) ) //&& !isVisible
+	{
+		std::cerr << ">Vid window is visible." << std::endl;
+		visTime = SDL_GetTicks();
+		isVisible = 1;
+	}
+	
+}
+
+void Video::Invisible()
+{
+	Uint32 winFlags;
+
+	SDL_HideWindow(context.window);
+	winFlags = SDL_GetWindowFlags(context.window);
+	if ((winFlags & SDL_WINDOW_HIDDEN) ) //&& isVisible != 0
+	{
+		std::cerr << ">Vid window is hidden." << std::endl;
+		isVisible = 0;
+	}
+	
+}
+
+int Video::VisibleState()
+{
+	return(isVisible);
+}
+
+void Video::CleanUp()
+{
+	if (isValid > 0)
+	{
+		
+		// Stop stream and clean up libVLC.
+		libvlc_media_player_stop(mp);
+		libvlc_media_player_release(mp);
+	}
+
+	if(libvlc != NULL)
+		libvlc_release(libvlc);
+
+	// Close window and clean up libSDL.
+    SDL_DestroyMutex(context.mutex);
+    SDL_DestroyRenderer(context.renderer);
+	SDL_DestroyWindow(context.window);
+
+}
+
+
+
+/*
+//callback to detect when the video has stopped playing
+int VidIsPlaying;
+void videoEnded(const libvlc_event_t *event, void *vidPlaying)
+{
+	std::cerr << "VideoEnd callback (" << vidPlaying << "):(";
+	*vidPlaying = 0;
+	std::cerr << vidPlaying << "):  ";
+
+}
+*/

--- a/vlcVideoPlayerSM.h
+++ b/vlcVideoPlayerSM.h
@@ -1,0 +1,142 @@
+#ifndef VLCVIDEOPLAYERSM_H
+#define VLCVIDEOPLAYERSM_H
+#pragma once
+
+/************************************************************************
+This version of the VLC Video Player uses a state machine, rather than
+ relying on asynchronous calls to the libvlc. The reason for this change
+ is to improve the stability of the object and reduce deadlocking arising
+ from too many successive calls to libvlc media player that can cause race
+ conditions. Here, we wait for acknowledgements about changes in state before
+ continuing with various multi-step operations such as resetting the video. 
+
+ This approach appears to work, but has not been fully tested as of 3/6/2019.
+ To implement this object, use the function calls to request changes in state
+ of the video player (e.g., play, stop, reset, etc) but also remember to call
+ Update() on every loop (e.g., in conjunction with each pass through the main
+ state machine controlling the experiment) to keep the Video Player state
+ machine updated and to allow all commands to complete for a given state change
+ request. 
+
+ Note, this player does NOT require VLC to be installed on the current computer.
+ However, it may require that a copy of the VLC plugins folder be placed in the
+ same parent folder as the program executable (along with libvlc.dll and 
+ libvlccore.dll). It also requires that Shlwapi.lib be added to the linker properties.
+
+
+ */
+
+
+
+#include <SDL.h>
+#include <SDL_mutex.h>
+#include "SDL_filesystem.h"
+#include "config.h"
+#include <iostream>
+#include <sstream>
+#include "vlc/vlc.h"
+#include <Shlwapi.h>
+
+
+
+struct ctx {
+	SDL_Window *window;
+    SDL_Renderer *renderer;
+    SDL_Texture *texture;
+    SDL_mutex *mutex;
+	SDL_Rect rect;
+	float xpos;
+	float ypos;
+	int showVideo;
+};
+
+
+//to draw other stuff in the video
+static void (*drawfunc)(SDL_Renderer *renderer);  //function pointer to a function that draws other stuff
+void DrawOtherStuff(void (*func)(SDL_Renderer *renderer)); //function call that allows us to store the draw-function pointer
+
+//callback functions
+static void* lock(void *data, void **p_pixels);
+static void unlock(void *data, void *id, void *const *p_pixels);
+static void display(void *data, void *id);
+
+
+
+class Video
+{
+private:
+	struct ctx context; //Video/SDL context
+	
+	//State machine states
+	enum VidState
+	{
+		Load = 0x01,		//00001
+		Idle = 0x02,		//00010
+		Playing = 0x04,		//00100
+		Paused = 0x05,		//00101
+		Stopped = 0x06,		//00110
+		Ended = 0x07,		//00111
+		Rewind = 0x12		//01100
+	};
+
+
+	VidState state;
+	bool enteredstate;
+	int requestplay;
+	int requeststop;
+	int requestpause;
+	int requestrewind;
+	int requestload;
+
+	//some VLC parameters
+	libvlc_instance_t *libvlc;
+    libvlc_media_t *m;
+    libvlc_media_player_t *mp;
+	libvlc_event_manager_t *mpevent;
+	libvlc_state_t mpstate;
+
+	//some status parameters
+	int hasStarted;
+	int hasEnded;
+	int hasStopped;
+
+	int VidLoad(const char* fname);
+	
+	int isValid;  //flag to identify that the video is actually valid!
+	int isVisible;
+	Uint32 visTime;
+	float vidPos;
+
+public:
+
+	Video(const char* fname, int x, int y, int w, int h, int* errorcode);  //constructor function
+	//int Init();
+	~Video() { };
+	
+	void SetPos(int x, int y); //function to set the position of the video on the screen
+
+	int GetStatus();	//function to get the current status (updates and returns VLC state)
+	int IsValid();		//querry if the current video is valids
+	int HasStarted();	//function to find out if video playing has started
+	int HasEnded();		//function to find out if video playing has ended
+	int HasStopped();	//function to find out if the video playing has stopped
+	void ResetStatus();	//reset the status flags - does NOT affect the actual video status
+	void SetValidStatus(int status);
+
+	int Play();		//request start playing the video
+	int Stop();		//request stop playing the video
+	int Pause();	//request pause playing the video
+	int LoadNewVid(const char* fname);	//load a new video using the same context
+
+	int Update();	//update the state machine
+	int ResetVid();	//Reset the video back to the beginning for the next playback
+	
+	void Visible();	//make the video window visible
+	void Invisible(); //make the video window invisible
+	int VisibleState(); //querry the visibility state
+
+	void CleanUp();	//cleans up VLC stuff
+
+};
+
+#endif


### PR DESCRIPTION
State Machine version of VLC Video Player object seems to be working, and appears more stable. Also added some nice tweaks like faster loading of new videos involving only destroying/creating a new VLC media player and not having to destroy/recreate the whole SDL window.